### PR TITLE
Inherit Equipment Grids

### DIFF
--- a/data-final-fixes.lua
+++ b/data-final-fixes.lua
@@ -25,6 +25,6 @@ local function inherit_grid(base_name, copy_to_name)
 end
 
 inherit_grid("locomotive", "electric-locomotive")
-inherit_grid("locomotive", "electric-wagon-locomotive")
+inherit_grid("locomotive", "electric-locomotive-wagon")
 inherit_grid("cargo-wagon", "electric-cargo-wagon")
 inherit_grid("fluid-wagon", "electric-fluid-wagon")

--- a/data-final-fixes.lua
+++ b/data-final-fixes.lua
@@ -25,5 +25,6 @@ local function inherit_grid(base_name, copy_to_name)
 end
 
 inherit_grid("locomotive", "electric-locomotive")
+inherit_grid("locomotive", "electric-wagon-locomotive")
 inherit_grid("cargo-wagon", "electric-cargo-wagon")
 inherit_grid("fluid-wagon", "electric-fluid-wagon")

--- a/data-final-fixes.lua
+++ b/data-final-fixes.lua
@@ -3,25 +3,25 @@
 local function inherit_grid(base_name, copy_to_name)
   -- Ensure that base technologies exist.
   if not data.raw[base_name] or not data.raw[base_name][base_name] or not data.raw[base_name][copy_to_name] then
-    log("Technology doesn't exist")
+    -- log("Technology doesn't exist")
     return
   end
 
   -- Skip inheriting if something else has already given the prototype an equipment grid.
   if data.raw[base_name][copy_to_name].equipment_grid then
-    log("New prototype already has a grid.")
+    -- log("New prototype already has a grid.")
     return
   end
 
   -- We also only want to inherit if there's something *to* inherit.
   local new_grid = data.raw[base_name][base_name].equipment_grid
   if not new_grid then
-    log("Existing prototype '" .. base_name .. "' does not have an equipment grid.")
+    -- log("Existing prototype '" .. base_name .. "' does not have an equipment grid.")
     return
   end
 
   data.raw[base_name][copy_to_name].equipment_grid = new_grid
-  log("Successfully inherited equipment grid '" .. new_grid .. "' from " .. base_name .. " to " .. copy_to_name .. ".")
+  -- log("Successfully inherited equipment grid '" .. new_grid .. "' from " .. base_name .. " to " .. copy_to_name .. ".")
 end
 
 inherit_grid("locomotive", "electric-locomotive")

--- a/data-final-fixes.lua
+++ b/data-final-fixes.lua
@@ -1,0 +1,29 @@
+
+-- Inherit the base locomotive equipment grid.
+local function inherit_grid(base_name, copy_to_name)
+  -- Ensure that base technologies exist.
+  if not data.raw[base_name] or not data.raw[base_name][base_name] or not data.raw[base_name][copy_to_name] then
+    log("Technology doesn't exist")
+    return
+  end
+
+  -- Skip inheriting if something else has already given the prototype an equipment grid.
+  if data.raw[base_name][copy_to_name].equipment_grid then
+    log("New prototype already has a grid.")
+    return
+  end
+
+  -- We also only want to inherit if there's something *to* inherit.
+  local new_grid = data.raw[base_name][base_name].equipment_grid
+  if not new_grid then
+    log("Existing prototype '" .. base_name .. "' does not have an equipment grid.")
+    return
+  end
+
+  data.raw[base_name][copy_to_name].equipment_grid = new_grid
+  log("Successfully inherited equipment grid '" .. new_grid .. "' from " .. base_name .. " to " .. copy_to_name .. ".")
+end
+
+inherit_grid("locomotive", "electric-locomotive")
+inherit_grid("cargo-wagon", "electric-cargo-wagon")
+inherit_grid("fluid-wagon", "electric-fluid-wagon")


### PR DESCRIPTION
This change is meant to allow electric locomotives and electric wagons to have an equipment grid. It does this by grabbing the `equipment_grid` string from the base technology. If the base technology doesn't have a grid, or if some other mod modified our trains to have a different grid, no changes will be made.

For example, Krastorio 2 adds an equipment grid to both the vanilla locomotive and to vanilla cargo/fluid wagons. With this code, electric trains will inherit this change and use the same size grid, with the same category restrictions.

I had to put this in data-final-fixes instead of data-updates, otherwise we would need to define optional dependencies to ensure the load order is correct.

Tested with Space Exploration + Krastorio 2, as well as without either mod. Because `equipment_grid` is only a string referencing a previously defined grid, I don't anticipate any other work needed on our end.