### PR TITLE
feat: add "Extended" option to settings

### DIFF
--- a/data-updates.lua
+++ b/data-updates.lua
@@ -9,6 +9,10 @@ elseif settings.startup["electric-locomotive-speed-setting"].value == "378 km/h"
   data.raw["locomotive"]["electric-locomotive"].max_speed = 1.75
   data.raw["cargo-wagon"]["electric-cargo-wagon"].max_speed = 1.75
   data.raw["fluid-wagon"]["electric-fluid-wagon"].max_speed = 1.75
+elseif settings.startup["electric-locomotive-speed-setting"].value == "714 km/h (Extended)" then
+  data.raw["locomotive"]["electric-locomotive"].max_speed = 3.0
+  data.raw["cargo-wagon"]["electric-cargo-wagon"].max_speed = 3.0
+  data.raw["fluid-wagon"]["electric-fluid-wagon"].max_speed = 3.0
 end
 
 if settings.startup["electric-cargo-wagon-capacity-setting"].value == "40 Slots (Vanilla)" then
@@ -19,6 +23,8 @@ end
 
 if settings.startup["electric-fluid-wagon-capacity-setting"].value == "50.000 (Vanilla)" then
   data.raw["fluid-wagon"]["electric-fluid-wagon"].capacity = 50000
+elseif settings.startup["electric-fluid-wagon-capacity-setting"].value == "150.000 (Extended)" then
+  data.raw["fluid-wagon"]["electric-fluid-wagon"].capacity = 150000
 end
 
 if settings.startup["train-battery-pack-energy-density-setting"].value == "80 MJ" then

--- a/data-updates.lua
+++ b/data-updates.lua
@@ -10,9 +10,9 @@ elseif settings.startup["electric-locomotive-speed-setting"].value == "378 km/h"
   data.raw["cargo-wagon"]["electric-cargo-wagon"].max_speed = 1.75
   data.raw["fluid-wagon"]["electric-fluid-wagon"].max_speed = 1.75
 elseif settings.startup["electric-locomotive-speed-setting"].value == "714 km/h (Extended)" then
-  data.raw["locomotive"]["electric-locomotive"].max_speed = 3.0
-  data.raw["cargo-wagon"]["electric-cargo-wagon"].max_speed = 3.0
-  data.raw["fluid-wagon"]["electric-fluid-wagon"].max_speed = 3.0
+  data.raw["locomotive"]["electric-locomotive"].max_speed = 3.3
+  data.raw["cargo-wagon"]["electric-cargo-wagon"].max_speed = 3.3
+  data.raw["fluid-wagon"]["electric-fluid-wagon"].max_speed = 3.3
 end
 
 if settings.startup["electric-cargo-wagon-capacity-setting"].value == "40 Slots (Vanilla)" then

--- a/settings.lua
+++ b/settings.lua
@@ -15,7 +15,7 @@ data:extend({{
   name = "electric-fluid-wagon-capacity-setting",
   setting_type = "startup",
   default_value = "60.000 (Default)",
-  allowed_values = {"50.000 (Vanilla)", "60.000 (Default)"}
+  allowed_values = {"50.000 (Vanilla)", "60.000 (Default)", "150.000 (Extended)"}
 }, {
   type = "string-setting",
   name = "electric-cargo-wagon-capacity-setting",
@@ -27,5 +27,5 @@ data:extend({{
   name = "electric-locomotive-speed-setting",
   setting_type = "startup",
   default_value = "518 km/h (Default)",
-  allowed_values = {"238 km/h (Vanilla)", "378 km/h", "518 km/h (Default)"}
+  allowed_values = {"238 km/h (Vanilla)", "378 km/h", "518 km/h (Default)", "714 km/h (Extended)"}
 }})


### PR DESCRIPTION
I have seen that you provided the "Extended" option for fluid wagon capacity which was 3x the "Vanilla" capacity.

I found myself wanting an "Extended" (or 3x) option for the cargo wagaon capacity so I though why not add that + the "Extended" option for the max speed.

